### PR TITLE
Updating scala-lambda page

### DIFF
--- a/_posts/2013-09-12-scala-lambdas.md
+++ b/_posts/2013-09-12-scala-lambdas.md
@@ -34,7 +34,7 @@ Especially in functional programming, using lambdas can allow us to create highl
 Lambdas in Scala are pretty simple in syntax: they are defined by their function signature. Lets look at this in the Scala REPL:
 
 {% highlight scala %}
-scala> (l: Long) =< l * l
+scala> (l: Long) => l * l
 res0: Long =&gt; Long = &lt;function1&gt;
 {% endhighlight %}
 


### PR DESCRIPTION
Fix direction of arrow (from `=<` to `=>`) for defining lambda for the first code segment.